### PR TITLE
Fix Location import for Astral v2.0+

### DIFF
--- a/automathemely/autoth_tools/updsuntimes.py
+++ b/automathemely/autoth_tools/updsuntimes.py
@@ -5,7 +5,7 @@ from time import sleep
 
 import pytz
 import tzlocal
-from astral import Location
+from astral import LocationInfo
 
 from automathemely.autoth_tools.utils import get_local, verify_desktop_session
 
@@ -63,7 +63,7 @@ def main(us_se):
         loc = us_se['location']['manual']
 
     try:
-        location = Location()
+        location = LocationInfo()
         location.name = loc['city']
         location.region = loc['region']
         location.latitude = loc['latitude']


### PR DESCRIPTION
Astral v2.0+ 

> Geocoder functions return a **LocationInfo** instead of a **Location**

https://astral.readthedocs.io/en/latest/#version-history

Opening AutomaThemely on my up-to-date Arch system (including Python v3.8) results in a traceback due to this Astral change:

```
> automathemely
Traceback (most recent call last):
  File "/usr/bin/automathemely", line 11, in <module>
    load_entry_point('AutomaThemely==1.3', 'console_scripts', 'automathemely')()
  File "/usr/lib/python3.8/site-packages/automathemely/bin/run.py", line 29, in main
    from automathemely.autoth_tools import argmanager, extratools, envspecific, updsuntimes
  File "/usr/lib/python3.8/site-packages/automathemely/autoth_tools/updsuntimes.py", line 8, in <module>
    from astral import Location
ImportError: cannot import name 'Location' from 'astral' (/usr/lib/python3.8/site-packages/astral/__init__.py)
```

Previous PR https://github.com/C2N14/AutomaThemely/pull/35 was made in error. This is my first time opening a PR so I'm hoping everything is correct now.