### PR TITLE
[feature] Command line option to toggle theme mode

### DIFF
--- a/automathemely/autoth_tools/argmanager.py
+++ b/automathemely/autoth_tools/argmanager.py
@@ -19,7 +19,8 @@ options.add_argument('-u', '--update', help='update the sunrise and sunset\'s ti
 options.add_argument('-r', '--restart',
                      help='(re)start the scheduler script if it were to not start or stop unexpectedly',
                      action='store_true', default=False)
-
+options.add_argument('-L', '--light', help='apply light theme', action='store_true', default=False)
+options.add_argument('-D', '--dark', help='apply dark theme', action='store_true', default=False)
 
 #   For --list arg
 def print_list(d, indent=0):
@@ -119,3 +120,10 @@ def main(us_se):
             Popen(['pkill', '-f', 'autothscheduler.py']).wait()
         Popen(['python3', get_bin('autothscheduler.py')], start_new_session=True, stdout=DEVNULL, stderr=DEVNULL)
         logger.info('Restarted the scheduler')
+    
+    #   MANUAL theme mode
+    elif args.light:
+        return 'light'
+    elif args.dark:
+        return 'dark'
+

--- a/automathemely/autoth_tools/extratools.py
+++ b/automathemely/autoth_tools/extratools.py
@@ -57,9 +57,9 @@ def get_installed_extra_themes(extra):
 
         # All possible paths that I know of that can contain VSCode extensions
         vscode_extensions_paths = ['/snap/vscode/current/usr/share/code/resources/app/extensions',
-                                   '/usr/share/code/resources/app/extensions',
                                    str(Path.home().joinpath('.vscode', 'extensions')),
                                    '/usr/lib/extensions',
+                                   '/usr/share/code/resources/app/extensions',
                                    '/opt/visual-studio-code/resources/app/extensions']
         vscode_themes = []
         for p in vscode_extensions_paths:

--- a/automathemely/autoth_tools/updsuntimes.py
+++ b/automathemely/autoth_tools/updsuntimes.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 import logging
 from datetime import timedelta
+from datetime import date
 from time import sleep
 
 import pytz
 import tzlocal
-from astral import Location
+from astral import LocationInfo
+from astral.sun import sun
 
 from automathemely.autoth_tools.utils import get_local, verify_desktop_session
 
@@ -63,7 +65,7 @@ def main(us_se):
         loc = us_se['location']['manual']
 
     try:
-        location = Location()
+        location = LocationInfo()
         location.name = loc['city']
         location.region = loc['region']
         location.latitude = loc['latitude']
@@ -72,9 +74,10 @@ def main(us_se):
     except ValueError as e:
         logger.error(str(e))
         return
-
-    sunrise = location.sun()['sunrise'].replace(second=0) + timedelta(minutes=us_se['offset']['sunrise'])
-    sunset = location.sun()['sunset'].replace(second=0) + timedelta(minutes=us_se['offset']['sunset'])
+	
+    s = sun(location.observer, date=date.today(), tzinfo=pytz.timezone(location.timezone))
+    sunrise = s['sunrise'].replace(second=0) + timedelta(minutes=us_se['offset']['sunrise'])
+    sunset = s['sunset'].replace(second=0) + timedelta(minutes=us_se['offset']['sunset'])
 
     #   Convert to UTC for storage
     return sunrise.astimezone(pytz.utc), sunset.astimezone(pytz.utc)

--- a/automathemely/bin/run.py
+++ b/automathemely/bin/run.py
@@ -81,10 +81,17 @@ def main():
         # Add the notification handler to the root logger
         logging.getLogger().addHandler(automathemely.notifier_handler)
 
+    theme = 'auto'
     #   If any argument is given, pass it/them to the arg manager module
     if len(sys.argv) > 1:
-        automathemely.autoth_tools.argmanager.main(user_settings)
-        return
+        mode = automathemely.autoth_tools.argmanager.main(user_settings)
+        # check if manual theme mode returned
+        if mode is None:
+            # auto theme mode; continue
+            return
+        else:
+            # set manual mode
+            theme = mode
 
     # We don't want to proceed until we have given the user the chance to review its settings
     if first_time_run:
@@ -106,10 +113,14 @@ def main():
     now = datetime.now(pytz.utc).astimezone(local_tz).time()
     sunrise, sunset = sunrise.astimezone(local_tz).time(), sunset.astimezone(local_tz).time()
 
-    if sunrise < now < sunset:
-        t_color = 'light'
+    if theme == 'auto':
+        if sunrise < now < sunset:
+            t_color = 'light'
+        else:
+            t_color = 'dark'
     else:
-        t_color = 'dark'
+        # set manual theme mode
+        t_color = theme
 
     logger.info('Switching to {} themes...'.format(t_color))
 


### PR DESCRIPTION
Themes can be switched by using command line argument

**Light theme**
`$ automathemely --light`

**Dark Theme**
`$ automathemely --dark`

Keyboard shortcuts can be assigned to run above commands from respective desktop environment's settings to toggle theme on the fly.