### PR TITLE
Add option to manually set theme

### DIFF
--- a/automathemely/autoth_tools/argmanager.py
+++ b/automathemely/autoth_tools/argmanager.py
@@ -19,6 +19,10 @@ options.add_argument('-u', '--update', help='update the sunrise and sunset\'s ti
 options.add_argument('-r', '--restart',
                      help='(re)start the scheduler script if it were to not start or stop unexpectedly',
                      action='store_true', default=False)
+options.add_argument('--light',
+                     help='manually set current theme to Light', action='store_true', default=False)
+options.add_argument('--dark',
+                     help='manually set current theme to Dark', action='store_true', default=False)
 
 
 #   For --list arg
@@ -119,3 +123,10 @@ def main(us_se):
             Popen(['pkill', '-f', 'autothscheduler.py']).wait()
         Popen(['python3', get_bin('autothscheduler.py')], start_new_session=True, stdout=DEVNULL, stderr=DEVNULL)
         logger.info('Restarted the scheduler')
+
+    #   MANUALLY SET THEME
+    elif args.light:
+        return "light"
+    elif args.dark:
+        return "dark"
+

--- a/automathemely/bin/run.py
+++ b/automathemely/bin/run.py
@@ -82,9 +82,11 @@ def main():
         logging.getLogger().addHandler(automathemely.notifier_handler)
 
     #   If any argument is given, pass it/them to the arg manager module
+    manual_theme_set = None
     if len(sys.argv) > 1:
-        automathemely.autoth_tools.argmanager.main(user_settings)
-        return
+        manual_theme_set = automathemely.autoth_tools.argmanager.main(user_settings)
+        if manual_theme_set is None:
+            return
 
     # We don't want to proceed until we have given the user the chance to review its settings
     if first_time_run:
@@ -110,6 +112,9 @@ def main():
         t_color = 'light'
     else:
         t_color = 'dark'
+
+    if manual_theme_set is not None:
+        t_color = manual_theme_set
 
     logger.info('Switching to {} themes...'.format(t_color))
 


### PR DESCRIPTION
A very simple PR that adds options for user to manually set theme.

This is very useful to quickly test out the new theme settings, or allow user to quickly set theme based on their preference by a simple command with `automathemely --light` or `automathemely --dark`