### PR TITLE
Adds support for background changing based on light/dark

### DIFF
--- a/automathemely/autoth_tools/envspecific.py
+++ b/automathemely/autoth_tools/envspecific.py
@@ -94,6 +94,7 @@ def get_installed_themes(desk_env):
 
     if desk_env == 'gnome':
         types['shell'] = True
+        types['background'] = True
 
     elif desk_env == 'kde':
         types['lookandfeel'] = True
@@ -156,6 +157,19 @@ def get_installed_themes(desk_env):
                                    .joinpath(t, 'gnome-shell', 'gnome-shell.css').is_file() and t.lower() != 'default')
 
         themes['shell'] = [(t,) for t in sort_remove_dupes(t_list)]
+
+    if types['background']:
+        from gi.repository import Gio
+        gsettings = Gio.Settings.new("org.gnome.desktop.background")
+
+        current_background = ""
+        try:
+            # this stores file path in the format of file:///home/xxx/xxx.jpg
+            current_background = gsettings["picture-uri"]
+        except KeyError:
+            pass
+
+        themes['background'] = current_background
 
     return themes
 
@@ -352,3 +366,12 @@ def set_theme(desk_env, t_type, theme):
         from gi.repository import Gio
         cinnamon_settings = Gio.Settings.new('org.cinnamon.theme')
         cinnamon_settings['name'] = theme
+
+    elif t_type == 'background':
+        from gi.repository import Gio
+        gnome_gsettings = Gio.Settings.new("org.gnome.desktop.background")
+        # Perform some sane checking
+        if theme:
+            if not theme.startswith("file://"):
+                theme = "file://{}".format(theme)
+            gnome_gsettings["picture-uri"] = theme

--- a/automathemely/lib/manager_gui.glade
+++ b/automathemely/lib/manager_gui.glade
@@ -460,6 +460,84 @@
                                                     </child>
                                                   </object>
                                                 </child>
+                                                <child>
+                                                  <object class="GtkListBoxRow">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <child>
+                                                      <object class="GtkGrid">
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="margin_left">12</property>
+                                                        <property name="margin_right">12</property>
+                                                        <property name="margin_top">8</property>
+                                                        <property name="margin_bottom">8</property>
+                                                        <property name="hexpand">True</property>
+                                                        <property name="vexpand">True</property>
+                                                        <property name="column_spacing">12</property>
+                                                        <child>
+                                                          <object class="GtkLabel">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="halign">start</property>
+                                                            <property name="valign">center</property>
+                                                            <property name="hexpand">True</property>
+                                                            <property name="vexpand">True</property>
+                                                            <property name="label" translatable="yes">Background</property>
+                                                          </object>
+                                                          <packing>
+                                                            <property name="left_attach">0</property>
+                                                            <property name="top_attach">0</property>
+                                                          </packing>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="margin_left">12</property>
+                                                            <property name="margin_right">12</property>
+                                                            <property name="margin_top">8</property>
+                                                            <property name="margin_bottom">8</property>
+                                                            <property name="spacing">12</property>
+                                                            <child>
+                                                              <object class="GtkEntry" id="*themes.gnome.light.background">
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">True</property>
+                                                                <signal name="changed" handler="on_any_change" swapped="no"/>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="expand">True</property>
+                                                                <property name="fill">True</property>
+                                                                <property name="position">0</property>
+                                                              </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkButton" id="bgchoose_button~*themes.gnome.light.background">
+                                                              <property name="visible">True</property>
+                                                              <property name="can_focus">True</property>
+                                                              <property name="receives_default">True</property>
+                                                              <property name="halign">end</property>
+                                                              <signal name="clicked" handler="on_bg_choose_file" swapped="no"/>
+                                                              <child>
+                                                                <object class="GtkImage">
+                                                                  <property name="visible">True</property>
+                                                                  <property name="can_focus">False</property>
+                                                                  <property name="stock">gtk-file</property>
+                                                                </object>
+                                                              </child>
+                                                            </object>
+                                                            <packing>
+                                                              <property name="expand">False</property>
+                                                              <property name="fill">True</property>
+                                                              <property name="position">1</property>
+                                                            </packing>
+                                                            </child>
+                                                          </object>
+                                                        </child>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                </child>
                                               </object>
                                             </child>
                                             <child type="tab">
@@ -610,6 +688,84 @@
                                                             <property name="left_attach">1</property>
                                                             <property name="top_attach">0</property>
                                                           </packing>
+                                                        </child>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkListBoxRow">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <child>
+                                                      <object class="GtkGrid">
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="margin_left">12</property>
+                                                        <property name="margin_right">12</property>
+                                                        <property name="margin_top">8</property>
+                                                        <property name="margin_bottom">8</property>
+                                                        <property name="hexpand">True</property>
+                                                        <property name="vexpand">True</property>
+                                                        <property name="column_spacing">12</property>
+                                                        <child>
+                                                          <object class="GtkLabel">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="halign">start</property>
+                                                            <property name="valign">center</property>
+                                                            <property name="hexpand">True</property>
+                                                            <property name="vexpand">True</property>
+                                                            <property name="label" translatable="yes">Background</property>
+                                                          </object>
+                                                          <packing>
+                                                            <property name="left_attach">0</property>
+                                                            <property name="top_attach">0</property>
+                                                          </packing>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="margin_left">12</property>
+                                                            <property name="margin_right">12</property>
+                                                            <property name="margin_top">8</property>
+                                                            <property name="margin_bottom">8</property>
+                                                            <property name="spacing">12</property>
+                                                            <child>
+                                                              <object class="GtkEntry" id="*themes.gnome.dark.background">
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">True</property>
+                                                                <signal name="changed" handler="on_any_change" swapped="no"/>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="expand">True</property>
+                                                                <property name="fill">True</property>
+                                                                <property name="position">0</property>
+                                                              </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkButton" id="bgchoose_button~*themes.gnome.dark.background">
+                                                              <property name="visible">True</property>
+                                                              <property name="can_focus">True</property>
+                                                              <property name="receives_default">True</property>
+                                                              <property name="halign">end</property>
+                                                              <signal name="clicked" handler="on_bg_choose_file" swapped="no"/>
+                                                              <child>
+                                                                <object class="GtkImage">
+                                                                  <property name="visible">True</property>
+                                                                  <property name="can_focus">False</property>
+                                                                  <property name="stock">gtk-file</property>
+                                                                </object>
+                                                              </child>
+                                                            </object>
+                                                            <packing>
+                                                              <property name="expand">False</property>
+                                                              <property name="fill">True</property>
+                                                              <property name="position">1</property>
+                                                            </packing>
+                                                            </child>
+                                                          </object>
                                                         </child>
                                                       </object>
                                                     </child>


### PR DESCRIPTION
Adds a new setting for changing in-between light background or dark background. This should able to extends to most desktop_env with `gsettings` supports as it's using
```
gsettings org.gnome.desktop.background ...
```
to get the current background and set the desire background.

However, this PR only adds gnome for now. This PR also includes a FileChooser dialog to choose the desire image in the GUI.