### PR TITLE
Small Typo with location import

### DIFF
--- a/automathemely/autoth_tools/updsuntimes.py
+++ b/automathemely/autoth_tools/updsuntimes.py
@@ -5,7 +5,7 @@ from time import sleep
 
 import pytz
 import tzlocal
-from astral import Location
+from astral import location
 
 from automathemely.autoth_tools.utils import get_local, verify_desktop_session
 


### PR DESCRIPTION
Hello,
I just updated the name of the Location class as with the capital letter the program refuse to start and I got the following error: 
ImportError: cannot import name 'Location' from 'astral' (/usr/lib/python3.8/site-packages/astral/__init__.py)

Cheers